### PR TITLE
maintenance: update gh actions

### DIFF
--- a/.github/workflows/release-catalog.yaml
+++ b/.github/workflows/release-catalog.yaml
@@ -14,9 +14,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v4.1.2
+      - uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-bin
           path: ./bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,10 @@ jobs:
     outputs:
       stable-release: ${{ env.NEW_RELEASE }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v4.1.2
+      - uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-bin
           path: ./bin


### PR DESCRIPTION
We have a deprecation warning on those actions: https://github.com/3scale-sre/prometheus-exporter-operator/actions/runs/14856084324

/kind config
/priority important-soon
/assign